### PR TITLE
Use default hikari pool size in java/spring

### DIFF
--- a/java/spring/src/main/resources/application.properties
+++ b/java/spring/src/main/resources/application.properties
@@ -22,5 +22,4 @@ spring.datasource.password=
 
 # HikariCP config (pool size, default isolation level).
 spring.datasource.type=com.zaxxer.hikari.HikariDataSource
-spring.datasource.hikari.maximumPoolSize=1
 spring.datasource.hikari.transactionIsolation=TRANSACTION_SERIALIZABLE


### PR DESCRIPTION
Now that https://github.com/YugaByte/yugabyte-db/commit/c7b3b0dae4e17ba56ea3a23e39fc21a474acdf3a has been implemented, we no longer need to limit the hikari maximum pool size to 1 to avoid #7.

**Note:** Do not merge until https://github.com/YugaByte/yugabyte-db/commit/c7b3b0dae4e17ba56ea3a23e39fc21a474acdf3a has been released.