### PR TITLE
Rust/Diesel: Introduce error messages for cases when internal server error is raised

### DIFF
--- a/rust/diesel/Cargo.lock
+++ b/rust/diesel/Cargo.lock
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "rocket"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -721,43 +721,43 @@ dependencies = [
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_http 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_codegen"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "devise 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_http 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_contrib"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_http"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1011,6 +1011,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "walkdir"
 version = "2.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,8 +1090,8 @@ dependencies = [
  "diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_contrib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_contrib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1174,10 +1179,10 @@ dependencies = [
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
-"checksum rocket 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "55b83fcf219c8b4980220231d5dd9eae167bdc63449fdab0a04b6c8b8cd361a8"
-"checksum rocket_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5549dc59a729fbd0e6f5d5de33ba136340228871633485e4946664d36289ffd7"
-"checksum rocket_contrib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5af691b5f5c06c3a30213217696681d3d3bdc2f10428fa3ce6bbaeab156b6409"
-"checksum rocket_http 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "abec045da00893bd4eef6084307a4bec0742278a7635a6a8b943da023202a5f7"
+"checksum rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "42c1e9deb3ef4fa430d307bfccd4231434b707ca1328fae339c43ad1201cc6f7"
+"checksum rocket_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "79aa1366f9b2eccddc05971e17c5de7bb75a5431eb12c2b5c66545fd348647f4"
+"checksum rocket_contrib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e0fa5c1392135adc0f96a02ba150ac4c765e27c58dbfd32aa40678e948f6e56f"
+"checksum rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b1391457ee4e80b40d4b57fa5765c0f2836b20d73bcbee4e3f35d93cf3b80817"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
@@ -1212,6 +1217,7 @@ dependencies = [
 "checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c7904a7e2bb3cdf0cf5e783f44204a85a37a93151738fa349f06680f59a98b45"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"

--- a/rust/diesel/Cargo.lock
+++ b/rust/diesel/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.6.10"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -22,6 +22,26 @@ dependencies = [
 name = "autocfg"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "backtrace"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "base64"
@@ -156,10 +176,32 @@ dependencies = [
 
 [[package]]
 name = "dotenv"
-version = "0.9.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -681,22 +723,22 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.11"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.5.6"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -770,6 +812,11 @@ dependencies = [
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc_version"
@@ -895,6 +942,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,7 +1001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ucd-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1088,7 +1146,7 @@ dependencies = [
  "bigdecimal 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dotenv 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dotenv 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1098,9 +1156,11 @@ dependencies = [
 ]
 
 [metadata]
-"checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
+"checksum aho-corasick 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "36b7aa1ccb7d7ea3f437cf025a2ab1c47cc6c1bc9fc84918ff449def12f5e282"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
+"checksum backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b5164d292487f037ece34ec0de2fcede2faa162f085dd96d2385ab81b12765ba"
+"checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bigdecimal 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "679e21a6734fdfc63378aea80c2bf31e6ac8ced21ed33e1ee37f8f7bf33c2056"
@@ -1116,7 +1176,9 @@ dependencies = [
 "checksum diesel 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8d24935ba50c4a8dc375a0fd1f8a2ba6bdbdc4125713126a74b965d6a01a06d7"
 "checksum diesel_derives 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62a27666098617d52c487a41f70de23d44a1dc1f3aa5877ceba2790fb1f1cab4"
 "checksum diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3cde8413353dc7f5d72fa8ce0b99a560a359d2c5ef1e5817ca731cd9008f4c"
-"checksum dotenv 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "400b347fe65ccfbd8f545c9d9a75d04b0caf23fec49aaa838a9a05398f94c019"
+"checksum dotenv 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4424bad868b0ffe6ae351ee463526ba625bbca817978293bbe6bb7dc1804a175"
+"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum filetime 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2f8c63033fcba1f51ef744505b3cad42510432b904c062afa67ad7ece008429d"
 "checksum fsevent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5ab7d1bd1bd33cc98b0889831b72da23c0aa4df9cec7e0702f46ecea04b35db6"
 "checksum fsevent-sys 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
@@ -1177,13 +1239,14 @@ dependencies = [
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+"checksum regex 1.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d9d8297cc20bbb6184f8b45ff61c8ee6a9ac56c156cec8e38c3e5084773c44ad"
+"checksum regex-syntax 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5485bf1523a9ed51c4964273f22f63f24e31632adb5dad134f488f86a3875c"
 "checksum ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
 "checksum rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "42c1e9deb3ef4fa430d307bfccd4231434b707ca1328fae339c43ad1201cc6f7"
 "checksum rocket_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "79aa1366f9b2eccddc05971e17c5de7bb75a5431eb12c2b5c66545fd348647f4"
 "checksum rocket_contrib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e0fa5c1392135adc0f96a02ba150ac4c765e27c58dbfd32aa40678e948f6e56f"
 "checksum rocket_http 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b1391457ee4e80b40d4b57fa5765c0f2836b20d73bcbee4e3f35d93cf3b80817"
+"checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
@@ -1201,13 +1264,14 @@ dependencies = [
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.38 (registry+https://github.com/rust-lang/crates.io-index)" = "37ea458a750f59ab679b47fef9b6722c586c5742f4cfe18a120bbc807e5e01fd"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
-"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
+"checksum ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa9b3b49edd3468c0e6565d85783f51af95212b6fa3986a5500954f00b460874"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"

--- a/rust/diesel/Cargo.lock
+++ b/rust/diesel/Cargo.lock
@@ -320,12 +320,12 @@ name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -377,7 +377,7 @@ dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -390,7 +390,7 @@ version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -557,7 +557,7 @@ name = "r2d2"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scheduled-thread-pool 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -717,7 +717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pear 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -748,7 +748,7 @@ name = "rocket_contrib"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.93 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1089,6 +1089,7 @@ dependencies = [
  "diesel 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1137,7 +1138,7 @@ dependencies = [
 "checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
 "checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum migrations_internals 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8089920229070f914b9ce9b07ef60e175b2b9bc2d35c3edd8bf4433604e863b9"

--- a/rust/diesel/Cargo.toml
+++ b/rust/diesel/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["svranesevic <svranesevic@users.noreply.github.com>"]
 edition = "2018"
 
 [dependencies]
-dotenv = "0.9.0"
+dotenv = "0.14.1"
 log = "0.4.8"
 rocket = "0.4.2"
 rocket_contrib = { version = "0.4.2", default-features = false, features = ["json"] }

--- a/rust/diesel/Cargo.toml
+++ b/rust/diesel/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 dotenv = "0.9.0"
+log = "0.4.8"
 rocket = "0.4.2"
 rocket_contrib = { version = "0.4.2", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/diesel/Cargo.toml
+++ b/rust/diesel/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 
 [dependencies]
 dotenv = "0.9.0"
-rocket = "0.4.1"
-rocket_contrib = { version = "0.4.1", default-features = false, features = ["json"] }
+rocket = "0.4.2"
+rocket_contrib = { version = "0.4.2", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bigdecimal = { version = "0.0.14", features = ["serde"]}

--- a/rust/diesel/rust-toolchain
+++ b/rust/diesel/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2019-08-01

--- a/rust/diesel/src/api.rs
+++ b/rust/diesel/src/api.rs
@@ -1,0 +1,38 @@
+use core::fmt;
+use rocket::http::Status;
+use rocket::response::Responder;
+use rocket::{Request, Response};
+use std::error::Error as StdError;
+
+#[derive(Debug)]
+pub enum ApiError {
+    NotFound,
+    InternalServerError,
+}
+
+impl<'a> Responder<'a> for ApiError {
+    fn respond_to(self, _request: &Request) -> Result<Response<'a>, Status> {
+        match self {
+            ApiError::NotFound => Err(Status::NotFound),
+            _ => Err(Status::InternalServerError),
+        }
+    }
+}
+
+impl fmt::Display for ApiError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ApiError::NotFound => f.write_str("NotFound"),
+            ApiError::InternalServerError => f.write_str("InternalServerError"),
+        }
+    }
+}
+
+impl StdError for ApiError {
+    fn description(&self) -> &str {
+        match *self {
+            ApiError::NotFound => "Resource not found",
+            ApiError::InternalServerError => "Internal server error",
+        }
+    }
+}

--- a/rust/diesel/src/main.rs
+++ b/rust/diesel/src/main.rs
@@ -12,7 +12,6 @@ extern crate diesel_migrations;
 use rocket_contrib::json::JsonValue;
 
 mod api;
-
 mod db;
 mod schema;
 

--- a/rust/diesel/src/main.rs
+++ b/rust/diesel/src/main.rs
@@ -11,6 +11,8 @@ extern crate diesel_migrations;
 
 use rocket_contrib::json::JsonValue;
 
+mod api;
+
 mod db;
 mod schema;
 
@@ -28,6 +30,14 @@ fn not_found() -> JsonValue {
     json!({
         "status": "NotFound",
         "reason": "Resource was not found."
+    })
+}
+
+#[catch(500)]
+fn internal_error() -> JsonValue {
+    json!({
+        "status": "InternalServerError",
+        "reason": "Error occurred, try again."
     })
 }
 
@@ -59,6 +69,6 @@ fn main() {
                 order_api::delete_order
             ],
         )
-        .register(catchers![not_found])
+        .register(catchers![internal_error, not_found])
         .launch();
 }

--- a/rust/diesel/src/order.rs
+++ b/rust/diesel/src/order.rs
@@ -170,9 +170,10 @@ impl Order {
             .collect()
     }
 
-    pub fn delete(id: i32, connection: &PgConnection) -> bool {
+    pub fn delete(id: i32, connection: &PgConnection) -> Result<bool, String> {
         diesel::delete(orders::table.find(id))
             .execute(connection)
-            .is_ok()
+            .map(|aff_rows| aff_rows > 0)
+            .map_err(|err| err.to_string())
     }
 }

--- a/rust/diesel/src/order.rs
+++ b/rust/diesel/src/order.rs
@@ -90,7 +90,7 @@ impl Order {
         let row = Order {
             order_id: id,
             user_id: new_order.user_id,
-            order_total: new_order.order_total
+            order_total: new_order.order_total,
         };
 
         let update_result = connection
@@ -112,7 +112,10 @@ impl Order {
         update_result.map(|_| order).ok()
     }
 
-    fn create_new_order(order: &NewUserOrder, connection: &PgConnection) -> Option<(NewOrder, Vec<(Product, i16)>)> {
+    fn create_new_order(
+        order: &NewUserOrder,
+        connection: &PgConnection,
+    ) -> Option<(NewOrder, Vec<(Product, i16)>)> {
         let product_units: Vec<(Product, i16)> = order
             .products
             .iter()

--- a/rust/diesel/src/order.rs
+++ b/rust/diesel/src/order.rs
@@ -126,23 +126,19 @@ impl Order {
         order: &NewUserOrder,
         connection: &PgConnection,
     ) -> Result<(NewOrder, Vec<(Product, i16)>), String> {
-        let product_units: Vec<(Product, i16)> = {
-            let result: Result<Vec<(Product, i16)>, String> = order
-                .products
-                .iter()
-                .map(
-                    |product_ref| match Product::read(product_ref.product_id, connection)? {
-                        None => Err(format!(
-                            "Product with id {} does not exist",
-                            product_ref.product_id
-                        )),
-                        Some(product) => Ok((product, product_ref.units)),
-                    },
-                )
-                .collect();
-
-            result?
-        };
+        let product_units: Vec<(Product, i16)> = order
+            .products
+            .iter()
+            .map(
+                |product_ref| match Product::read(product_ref.product_id, connection)? {
+                    None => Err(format!(
+                        "Product with id {} does not exist",
+                        product_ref.product_id
+                    )),
+                    Some(product) => Ok((product, product_ref.units)),
+                },
+            )
+            .collect::<Result<Vec<_>, _>>()?;
 
         let order_total = product_units
             .iter()

--- a/rust/diesel/src/order_api.rs
+++ b/rust/diesel/src/order_api.rs
@@ -65,6 +65,13 @@ pub fn update_order(
 }
 
 #[delete("/orders/<order_id>")]
-pub fn delete_order(order_id: i32, connection: db::Connection) {
-    Order::delete(order_id, &connection);
+pub fn delete_order(order_id: i32, connection: db::Connection) -> Result<Option<()>, ApiError> {
+    match Order::delete(order_id, &connection) {
+        Ok(true) => Ok(Some(())),
+        Ok(false) => Err(ApiError::NotFound),
+        Err(err) => {
+            error!("Unable to delete user - {}", err);
+            Err(ApiError::InternalServerError)
+        }
+    }
 }

--- a/rust/diesel/src/order_api.rs
+++ b/rust/diesel/src/order_api.rs
@@ -65,9 +65,9 @@ pub fn update_order(
 }
 
 #[delete("/orders/<order_id>")]
-pub fn delete_order(order_id: i32, connection: db::Connection) -> Result<Option<()>, ApiError> {
+pub fn delete_order(order_id: i32, connection: db::Connection) -> Result<(), ApiError> {
     match Order::delete(order_id, &connection) {
-        Ok(true) => Ok(Some(())),
+        Ok(true) => Ok(()),
         Ok(false) => Err(ApiError::NotFound),
         Err(err) => {
             error!("Unable to delete user - {}", err);

--- a/rust/diesel/src/order_api.rs
+++ b/rust/diesel/src/order_api.rs
@@ -35,9 +35,9 @@ pub fn update_order(
     order_id: i32,
     order: Json<NewUserOrder>,
     connection: db::Connection,
-) -> Json<NewUserOrder> {
-    let updated_order = Order::update(order_id, order.into_inner(), &connection).unwrap();
-    Json(updated_order)
+) -> Option<Json<NewUserOrder>> {
+    let updated_order = Order::update(order_id, order.into_inner(), &connection);
+    updated_order.map(Json)
 }
 
 #[delete("/orders/<order_id>")]

--- a/rust/diesel/src/order_api.rs
+++ b/rust/diesel/src/order_api.rs
@@ -1,13 +1,33 @@
+use log::error;
 use rocket_contrib::json::Json;
 use serde::Serialize;
 
+use crate::api::ApiError;
 use crate::db;
 use crate::order::{NewUserOrder, Order};
 
 #[post("/orders", data = "<order>", format = "json")]
-pub fn create_order(order: Json<NewUserOrder>, connection: db::Connection) -> &'static str {
-    Order::create(order.into_inner(), &connection);
-    "TBD"
+pub fn create_order(
+    order: Json<NewUserOrder>,
+    connection: db::Connection,
+) -> Result<&'static str, ApiError> {
+    Order::create(order.into_inner(), &connection)
+        .map(|_| "TBD")
+        .map_err(|err| {
+            error!("Unable to create order - {}", err);
+            ApiError::InternalServerError
+        })
+}
+
+#[get("/orders")]
+pub fn read_orders(connection: db::Connection) -> Result<Json<OrdersResponse>, ApiError> {
+    Order::read_all(&connection)
+        .map(|orders| OrdersResponse { content: orders })
+        .map(Json)
+        .map_err(|err| {
+            error!("Unable to read orders - {}", err);
+            ApiError::InternalServerError
+        })
 }
 
 #[derive(Serialize)]
@@ -16,18 +36,16 @@ pub struct OrdersResponse {
     content: Vec<Order>,
 }
 
-#[get("/orders")]
-pub fn read_orders(connection: db::Connection) -> Json<OrdersResponse> {
-    let response = OrdersResponse {
-        content: Order::read_all(&connection),
-    };
-
-    Json(response)
-}
-
 #[get("/orders/<order_id>")]
-pub fn read_order(order_id: i32, connection: db::Connection) -> Option<Json<Order>> {
-    Order::read(order_id, &connection).map(Json)
+pub fn read_order(order_id: i32, connection: db::Connection) -> Result<Json<Order>, ApiError> {
+    match Order::read(order_id, &connection) {
+        Ok(Some(order)) => Ok(Json(order)),
+        Ok(None) => Err(ApiError::NotFound),
+        Err(err) => {
+            error!("Unable to read order - {}", err);
+            Err(ApiError::InternalServerError)
+        }
+    }
 }
 
 #[put("/orders/<order_id>", data = "<order>", format = "json")]
@@ -35,9 +53,15 @@ pub fn update_order(
     order_id: i32,
     order: Json<NewUserOrder>,
     connection: db::Connection,
-) -> Option<Json<NewUserOrder>> {
-    let updated_order = Order::update(order_id, order.into_inner(), &connection);
-    updated_order.map(Json)
+) -> Result<Json<NewUserOrder>, ApiError> {
+    match Order::update(order_id, order.into_inner(), &connection) {
+        Ok(Some(order)) => Ok(Json(order)),
+        Ok(None) => Err(ApiError::NotFound),
+        Err(err) => {
+            error!("Unable to update user - {}", err);
+            Err(ApiError::InternalServerError)
+        }
+    }
 }
 
 #[delete("/orders/<order_id>")]

--- a/rust/diesel/src/product.rs
+++ b/rust/diesel/src/product.rs
@@ -25,29 +25,42 @@ pub struct NewProduct {
 }
 
 impl Product {
-    pub fn create(product: NewProduct, connection: &PgConnection) -> Product {
+    pub fn create(product: NewProduct, connection: &PgConnection) -> Result<Product, String> {
         diesel::insert_into(products::table)
             .values(&product)
             .get_result(connection)
-            .unwrap()
+            .map_err(|err| err.to_string())
     }
 
-    pub fn read_all(connection: &PgConnection) -> Vec<Product> {
+    pub fn read_all(connection: &PgConnection) -> Result<Vec<Product>, String> {
         products::table
             .order(products::product_id)
             .load::<Product>(connection)
-            .unwrap()
+            .map_err(|err| err.to_string())
     }
 
-    pub fn read(id: i32, connection: &PgConnection) -> Option<Product> {
-        products::table.find(id).get_result(connection).ok()
+    pub fn read(id: i32, connection: &PgConnection) -> Result<Option<Product>, String> {
+        match products::table.find(id).first(connection) {
+            Ok(product) => Ok(Some(product)),
+            Err(diesel::result::Error::NotFound) => Ok(None),
+            Err(err) => Err(err.to_string()),
+        }
     }
 
-    pub fn update(id: i32, product: Product, connection: &PgConnection) -> Option<Product> {
+    pub fn update(
+        id: i32,
+        product: Product,
+        connection: &PgConnection,
+    ) -> Result<Option<Product>, String> {
         let update_result = diesel::update(products::table.find(id))
             .set(&product)
             .execute(connection);
-        update_result.map(|_| product).ok()
+
+        match update_result {
+            Err(diesel::result::Error::NotFound) | Ok(0) => Ok(None),
+            Err(err) => Err(err.to_string()),
+            Ok(_) => Ok(Some(product)),
+        }
     }
 
     pub fn delete(id: i32, connection: &PgConnection) -> bool {

--- a/rust/diesel/src/product.rs
+++ b/rust/diesel/src/product.rs
@@ -63,9 +63,10 @@ impl Product {
         }
     }
 
-    pub fn delete(id: i32, connection: &PgConnection) -> bool {
+    pub fn delete(id: i32, connection: &PgConnection) -> Result<bool, String> {
         diesel::delete(products::table.find(id))
             .execute(connection)
-            .is_ok()
+            .map(|aff_rows| aff_rows > 0)
+            .map_err(|err| err.to_string())
     }
 }

--- a/rust/diesel/src/product_api.rs
+++ b/rust/diesel/src/product_api.rs
@@ -88,6 +88,13 @@ pub fn update_product(
 }
 
 #[delete("/products/<product_id>")]
-pub fn delete_product(product_id: i32, connection: db::Connection) {
-    Product::delete(product_id, &connection);
+pub fn delete_product(product_id: i32, connection: db::Connection) -> Result<Option<()>, ApiError> {
+    match Product::delete(product_id, &connection) {
+        Ok(true) => Ok(Some(())),
+        Ok(false) => Err(ApiError::NotFound),
+        Err(err) => {
+            error!("Unable to delete product - {}", err);
+            Err(ApiError::InternalServerError)
+        }
+    }
 }

--- a/rust/diesel/src/product_api.rs
+++ b/rust/diesel/src/product_api.rs
@@ -52,9 +52,9 @@ pub fn update_product(
     product_id: i32,
     product: Json<Product>,
     connection: db::Connection,
-) -> Json<Product> {
-    let updated_product = Product::update(product_id, product.into_inner(), &connection).unwrap();
-    Json(updated_product)
+) -> Option<Json<Product>> {
+    let updated_product = Product::update(product_id, product.into_inner(), &connection);
+    updated_product.map(Json)
 }
 
 #[delete("/products/<product_id>")]

--- a/rust/diesel/src/product_api.rs
+++ b/rust/diesel/src/product_api.rs
@@ -88,9 +88,9 @@ pub fn update_product(
 }
 
 #[delete("/products/<product_id>")]
-pub fn delete_product(product_id: i32, connection: db::Connection) -> Result<Option<()>, ApiError> {
+pub fn delete_product(product_id: i32, connection: db::Connection) -> Result<(), ApiError> {
     match Product::delete(product_id, &connection) {
-        Ok(true) => Ok(Some(())),
+        Ok(true) => Ok(()),
         Ok(false) => Err(ApiError::NotFound),
         Err(err) => {
             error!("Unable to delete product - {}", err);

--- a/rust/diesel/src/user.rs
+++ b/rust/diesel/src/user.rs
@@ -58,9 +58,10 @@ impl User {
         }
     }
 
-    pub fn delete(id: i32, connection: &PgConnection) -> bool {
+    pub fn delete(id: i32, connection: &PgConnection) -> Result<bool, String> {
         diesel::delete(users::table.find(id))
             .execute(connection)
-            .is_ok()
+            .map(|aff_rows| aff_rows > 0)
+            .map_err(|err| err.to_string())
     }
 }

--- a/rust/diesel/src/user_api.rs
+++ b/rust/diesel/src/user_api.rs
@@ -65,6 +65,13 @@ pub fn update_user(
 }
 
 #[delete("/users/<user_id>")]
-pub fn delete_user(user_id: i32, connection: db::Connection) {
-    User::delete(user_id, &connection);
+pub fn delete_user(user_id: i32, connection: db::Connection) -> Result<Option<()>, ApiError> {
+    match User::delete(user_id, &connection) {
+        Ok(true) => Ok(Some(())),
+        Ok(false) => Err(ApiError::NotFound),
+        Err(err) => {
+            error!("Unable to delete user - {}", err);
+            Err(ApiError::InternalServerError)
+        }
+    }
 }

--- a/rust/diesel/src/user_api.rs
+++ b/rust/diesel/src/user_api.rs
@@ -65,9 +65,9 @@ pub fn update_user(
 }
 
 #[delete("/users/<user_id>")]
-pub fn delete_user(user_id: i32, connection: db::Connection) -> Result<Option<()>, ApiError> {
+pub fn delete_user(user_id: i32, connection: db::Connection) -> Result<(), ApiError> {
     match User::delete(user_id, &connection) {
-        Ok(true) => Ok(Some(())),
+        Ok(true) => Ok(()),
         Ok(false) => Err(ApiError::NotFound),
         Err(err) => {
             error!("Unable to delete user - {}", err);

--- a/rust/diesel/src/user_api.rs
+++ b/rust/diesel/src/user_api.rs
@@ -1,12 +1,33 @@
+use log::error;
 use rocket_contrib::json::Json;
 use serde::Serialize;
 
+use crate::api::ApiError;
 use crate::db;
 use crate::user::{NewUser, User};
 
 #[post("/users", data = "<user>", format = "json")]
-pub fn create_user(user: Json<NewUser>, connection: db::Connection) -> Json<User> {
-    Json(User::create(user.into_inner(), &connection))
+pub fn create_user(
+    user: Json<NewUser>,
+    connection: db::Connection,
+) -> Result<Json<User>, ApiError> {
+    User::create(user.into_inner(), &connection)
+        .map(Json)
+        .map_err(|err| {
+            error!("Unable to create user - {}", err);
+            ApiError::InternalServerError
+        })
+}
+
+#[get("/users")]
+pub fn read_users(connection: db::Connection) -> Result<Json<UsersResponse>, ApiError> {
+    User::read_all(&connection)
+        .map(|users| UsersResponse { content: users })
+        .map(Json)
+        .map_err(|err| {
+            error!("Unable to read users - {}", err);
+            ApiError::InternalServerError
+        })
 }
 
 #[derive(Serialize)]
@@ -15,24 +36,32 @@ pub struct UsersResponse {
     content: Vec<User>,
 }
 
-#[get("/users")]
-pub fn read_users(connection: db::Connection) -> Json<UsersResponse> {
-    let response = UsersResponse {
-        content: User::read_all(&connection),
-    };
-
-    Json(response)
-}
-
 #[get("/users/<user_id>")]
-pub fn read_user(user_id: i32, connection: db::Connection) -> Option<Json<User>> {
-    User::read(user_id, &connection).map(Json)
+pub fn read_user(user_id: i32, connection: db::Connection) -> Result<Json<User>, ApiError> {
+    match User::read(user_id, &connection) {
+        Ok(Some(user)) => Ok(Json(user)),
+        Ok(None) => Err(ApiError::NotFound),
+        Err(err) => {
+            error!("Unable to read user - {}", err);
+            Err(ApiError::InternalServerError)
+        }
+    }
 }
 
 #[put("/users/<user_id>", data = "<user>", format = "json")]
-pub fn update_user(user_id: i32, user: Json<User>, connection: db::Connection) -> Option<Json<User>> {
-    let updated_user = User::update(user_id, user.into_inner(), &connection);
-    updated_user.map(Json)
+pub fn update_user(
+    user_id: i32,
+    user: Json<User>,
+    connection: db::Connection,
+) -> Result<Json<User>, ApiError> {
+    match User::update(user_id, user.into_inner(), &connection) {
+        Ok(Some(user)) => Ok(Json(user)),
+        Ok(None) => Err(ApiError::NotFound),
+        Err(err) => {
+            error!("Unable to update user - {}", err);
+            Err(ApiError::InternalServerError)
+        }
+    }
 }
 
 #[delete("/users/<user_id>")]

--- a/rust/diesel/src/user_api.rs
+++ b/rust/diesel/src/user_api.rs
@@ -30,9 +30,9 @@ pub fn read_user(user_id: i32, connection: db::Connection) -> Option<Json<User>>
 }
 
 #[put("/users/<user_id>", data = "<user>", format = "json")]
-pub fn update_user(user_id: i32, user: Json<User>, connection: db::Connection) -> Json<User> {
-    let updated_user = User::update(user_id, user.into_inner(), &connection).unwrap();
-    Json(updated_user)
+pub fn update_user(user_id: i32, user: Json<User>, connection: db::Connection) -> Option<Json<User>> {
+    let updated_user = User::update(user_id, user.into_inner(), &connection);
+    updated_user.map(Json)
 }
 
 #[delete("/users/<user_id>")]


### PR DESCRIPTION
I opted for returning `Result<..., String>` as I did not want to return concrete diesel errors (Read - leaky abstractions). Returned string contains user friendly error message.

Closes #40 