### PR TITLE
add instructions in README to create the DB: ysql_sequelize

### DIFF
--- a/node/sequelize/README.md
+++ b/node/sequelize/README.md
@@ -1,8 +1,17 @@
+# Prerequisites
+
+ysqlsh is installed and added to PATH
+
 # Build and run
 
 Install depedencies by running:
 ```
 $ npm install
+```
+
+Create Database
+```
+ysqlsh -c "CREATE DATABASE ysql_sequelize"
 ```
 
 To run, simply do:


### PR DESCRIPTION
Note that based on our testing we concluded that it is better to make user create the database, rather than the specific ORM trying to do so. 
When we made the ORM to manage creation of DB, we were running into various permission issues, hence in order to keep it simple we favored this approach