### PR TITLE
Domain name fix from yb.com to example.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository has examples showing build a simple REST API server using ORMs on top of YugaByte DB (using the YSQL API). The scenario modelled is that of a simple online e-commerce store. It consists of the following.
 
-* The users of the ecommerce site are stored in the `users` table. 
+* The users of the ecommerce site are stored in the `users` table.
 * The `products` table contains a list of products the ecommerce site sells.
 * The orders placed by the users are populated in the `orders` table. An order can consist of multiple line items, each of these are inserted in the `orderline` table.
 
@@ -32,10 +32,10 @@ By default, the REST API server listens on `localhost` port `8080`.
 
 ## Step 3. Create a user
 
-You can create a user named `John Smith` and email `jsmith@yb.com` as follows:
+You can create a user named `John Smith` and email `jsmith@example.com` as follows:
 
 ```
-$ curl --data '{ "firstName" : "John", "lastName" : "Smith", "email" : "jsmith@yb.com" }' \
+$ curl --data '{ "firstName" : "John", "lastName" : "Smith", "email" : "jsmith@example.com" }' \
        -v -X POST -H 'Content-Type:application/json' http://localhost:8080/users
 ```
 
@@ -45,7 +45,7 @@ This will return the inserted record as a JSON document:
   "userId": "1",
   "firstName": "John",
   "lastName": "Smith",
-  "email": "jsmith@yb.com"
+  "email": "jsmith@example.com"
 }
 ```
 
@@ -54,7 +54,7 @@ You can connect to YugaByte DB using `psql` and select these records:
 postgres=# select * from users;
  user_id | first_name | last_name |  user_email
 ---------+------------+-----------+---------------
-       1 | John       | Smith     | jsmith@yb.com(1 row)
+       1 | John       | Smith     | jsmith@example.com(1 row)
 ```
 
 ## Step 4. List all users
@@ -70,7 +70,7 @@ You should see the following output:
   "content": [
     {
       "userId":"1",
-      "email":"jsmith@yb.com",
+      "email":"jsmith@example.com",
       "firstName":"John",
       "lastName":"Smith"
     }

--- a/python/sqlalchemy/src/sample_requests.txt
+++ b/python/sqlalchemy/src/sample_requests.txt
@@ -1,11 +1,11 @@
 Create User
-curl --data '{ "firstName" : "John", "lastName" : "Smith", "email" : "jsmith@yb.com" }' \
+curl --data '{ "firstName" : "John", "lastName" : "Smith", "email" : "jsmith" }' \
        -v -X POST -H 'Content-Type:application/json' http://localhost:8080/users
 
 returns:
 {
   "user_id": 21,
-  "email": "jsmith@yb.com",
+  "email": "jsmith@example.com",
   "first_name": "John",
   "last_name": "Smith"
 }
@@ -23,7 +23,7 @@ curl http://localhost:8080/users
       "user_id": 4
     },
     {
-      "email": "jsmith@yb.com",
+      "email": "jsmith@example.com",
       "first_name": "John",
       "last_name": "Smith",
       "user_id": 8
@@ -36,7 +36,7 @@ curl http://localhost:8080/users
 curl --data '{ "productName": "Notebook", "description": "200 page notebook", "price": 7.50 }' \
   -v -X POST -H 'Content-Type:application/json' http://localhost:8080/products
 
-returns: 
+returns:
 {
   "description": "200 page notebook",
   "price": 7.5,
@@ -55,7 +55,7 @@ curl \
   --data '{ "productName": "Notebook", "description": "200 page notebook", "price": 7.50 }' \
   -v -X POST -H 'Content-Type:application/json' http://localhost:8080/list-products
 
-returns: 
+returns:
 {
   "products": [
     {
@@ -79,7 +79,7 @@ curl \
   --data '{ "userId": "1", "products": [ { "productId": 1, "quantity": 2 } ] }' \
   -v -X POST -H 'Content-Type:application/json' http://localhost:8080/orders
 
-returns: 
+returns:
 {
   "order_id": 17,
   "order_lines": [
@@ -102,7 +102,7 @@ curl --data '{ "userId": "1" }' \
   -v -X POST -H 'Content-Type:application/json' http://localhost:8080/list-orders
 
 
-returns: 
+returns:
 
 {
   "email": "syed@12techllc.com",
@@ -153,7 +153,7 @@ Check out multiple products in one order:
 curl --data '{ "userId": "1", "products": [ { "productId": 1, "quantity": 2 }, { "productId": 2, "quantity": 4 } ] }' \
 -v -X POST -H 'Content-Type:application/json' http://localhost:8080/orders
 
-Returns: 
+Returns:
 {
   "user_id": 4,
   "order_id": 16,


### PR DESCRIPTION
Summary:

With this repository being used for [Build an application pages] (https://docs.yugabyte.com/latest/quick-start/build-apps/python/ysql-sqlalchemy/#send-requests-to-the-application) , the email addresses in the API requests are using yb.com domain names. 
I've replaced it with example.com in 2 files.


