### PR TITLE
Update the EntityFramework orm app to use the latest .NET version(6.0)

### DIFF
--- a/csharp/entityframework/Startup.cs
+++ b/csharp/entityframework/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Hosting;
 using YugaByteStore.Models;
 
 namespace YugaByteStore
@@ -29,11 +30,11 @@ namespace YugaByteStore
             // Add framework services.
             services.AddDbContext<StoreDbContext>(options =>
             options.UseNpgsql(Configuration.GetConnectionString("DefaultConnection")));
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddMvc(options => options.EnableEndpointRouting = false);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -43,6 +44,7 @@ namespace YugaByteStore
             {
                 app.UseHsts();
             }
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
             app.UseHttpsRedirection();
             app.UseMvc();
             SeedData.Initialize(app.ApplicationServices);

--- a/csharp/entityframework/YugaByteStore.csproj
+++ b/csharp/entityframework/YugaByteStore.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.2" />
   </ItemGroup>
 
 </Project>

--- a/csharp/entityframework/appsettings.json
+++ b/csharp/entityframework/appsettings.json
@@ -6,6 +6,6 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "DefaultConnection": "Host=127.0.0.1;Port=5433;Username=postgres;Password=;Database=ysql_entityframework;"
+    "DefaultConnection": "Host=127.0.0.1;Port=5433;Username=yugabyte;Password=yugabyte;Database=ysql_entityframework;"
   }
 }


### PR DESCRIPTION
Changes made:
| File name | Change | Reason |
| - | - | --- |
| Startup.cs | <ul><li>`services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1)` --> `services.AddMvc(options => options.EnableEndpointRouting = false)`</li><li>`IHostingEnvironment` --> `IWebHostEnvironment` </li> <li>Added `AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true)`</li></ul> | <ul><li>`SetCompatibilityVersion()` no more supported since .NET 3.0. Also to use IRouter based routing logic the default Endpoint Routing logic needs to be set to false for versions 3.0 and above.</li><li>`IHostingEnvironment` is now obsolete.</li><li>Prior to 6.0, timestamp with time zone would be converted to a local timestamp when read. Now to get this behaviour  `AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true)` needs to be explicitly added. (We are using local timestamp in the orders table) Read more [here](https://www.npgsql.org/doc/types/datetime.html#timestamps-and-timezones)</li></ul> |
| YugabyteStore.csproj | <ul><li>`netcoreapp2.11` --> `net6.0`</li><li>Version of package `Npgsql.EntityFrameworkCore.PostgreSQL` from `2.0.1` --> `6.0.2`</li></ul> | <ul><li>Changing the dotnet target framework to the latest.</li><li>Changing the Package version to a comaptible one with .NET 6.0</li></ul> |
| appsettings.json | Changed the `DefaultConnection` setting to use the latest user and password |

Document to run this app : [Google Doc](https://docs.google.com/document/d/1Wbd9S6G5uXEH9w4NCyZClMljPYCq_sZCBIVEsEYgheo/edit#)