### PR TITLE
Improve Yugabyte load balancing setup

### DIFF
--- a/node/sequelize/README.md
+++ b/node/sequelize/README.md
@@ -26,7 +26,7 @@ $ DEBUG=sequelize:* npm start
 
 # Customizing
 
-Most settings come from environment variables (e.g. `YB_HOSTS`, `YB_LOAD_BALANCE`) or the file [config/config.json](https://github.com/YugaByte/orm-examples/blob/master/node/sequelize/config/config.json). The descriptions and default values are listed below.
+Most settings come from environment variables (e.g. `PGHOSTS`, `PGLOADBALANCE`) or the file [config/config.json](https://github.com/YugaByte/orm-examples/blob/master/node/sequelize/config/config.json). The descriptions and default values are listed below.
 
 | Properties    | Description   | Default |
 | ------------- | ------------- | ------- |
@@ -37,6 +37,22 @@ Most settings come from environment variables (e.g. `YB_HOSTS`, `YB_LOAD_BALANCE
 
 Environment examples:
 ```
-export YB_HOSTS=127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436
-export YB_LOAD_BALANCE=any
+# Multi-host setup (custom variable for load balancing)
+export PGHOSTS=127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436
+
+# Or single host using standard PostgreSQL variables
+export PGHOST=127.0.0.1
+export PGPORT=5436
+
+# Database credentials (standard PostgreSQL variables)
+export PGUSER=yugabyte
+export PGPASSWORD=yugabyte
+export PGDATABASE=ysql_sequelize
+
+# Load balancing configuration (YugabyteDB extensions)
+export PGLOADBALANCE=any
+export PGWRITELOADBALANCE=only-primary
+
+# Optional: Topology awareness
+export PGTOPOLOGYKEYS=cloud.region.zone
 ```

--- a/node/sequelize/README.md
+++ b/node/sequelize/README.md
@@ -36,31 +36,14 @@ Most settings come from environment variables (e.g. `PGHOST`, `PGLOADBALANCE`) o
 | `database` | Database name. | `ysql_sequelize` |
 
 Environment examples (using standard PostgreSQL variables):
-```
+```bash
 # Database connection (standard PostgreSQL variables)
 export PGHOST=127.0.0.1
-export PGPORT=5436
+export PGPORT=5433
 export PGUSER=yugabyte
 export PGPASSWORD=yugabyte
 export PGDATABASE=ysql_sequelize
 
-# Load balancing configuration (YugabyteDB extensions)
+# Load balancing configuration
 export PGLOADBALANCE=any
-export PGWRITELOADBALANCE=only-primary
-
-# Optional: Topology awareness
-export PGTOPOLOGYKEYS=cloud.region.zone
-```
-
-For multi-host load balancing, configure the `host` field in `config/config.json`:
-```json
-{
-  "development": {
-    "host": "127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436",
-    "username": "yugabyte",
-    "password": "yugabyte",
-    "database": "ysql_sequelize",
-    "port": "5436"
-  }
-}
 ```

--- a/node/sequelize/README.md
+++ b/node/sequelize/README.md
@@ -26,7 +26,7 @@ $ DEBUG=sequelize:* npm start
 
 # Customizing
 
-Most settings come from environment variables (e.g. `PGHOSTS`, `PGLOADBALANCE`) or the file [config/config.json](https://github.com/YugaByte/orm-examples/blob/master/node/sequelize/config/config.json). The descriptions and default values are listed below.
+Most settings come from environment variables (e.g. `PGHOST`, `PGLOADBALANCE`) or the file [config/config.json](https://github.com/YugaByte/orm-examples/blob/master/node/sequelize/config/config.json). The descriptions and default values are listed below.
 
 | Properties    | Description   | Default |
 | ------------- | ------------- | ------- |
@@ -35,16 +35,11 @@ Most settings come from environment variables (e.g. `PGHOSTS`, `PGLOADBALANCE`) 
 | `password` | The password to connect to the database. Leave blank for the password. | - |
 | `database` | Database name. | `ysql_sequelize` |
 
-Environment examples:
+Environment examples (using standard PostgreSQL variables):
 ```
-# Multi-host setup (custom variable for load balancing)
-export PGHOSTS=127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436
-
-# Or single host using standard PostgreSQL variables
+# Database connection (standard PostgreSQL variables)
 export PGHOST=127.0.0.1
 export PGPORT=5436
-
-# Database credentials (standard PostgreSQL variables)
 export PGUSER=yugabyte
 export PGPASSWORD=yugabyte
 export PGDATABASE=ysql_sequelize
@@ -55,4 +50,17 @@ export PGWRITELOADBALANCE=only-primary
 
 # Optional: Topology awareness
 export PGTOPOLOGYKEYS=cloud.region.zone
+```
+
+For multi-host load balancing, configure the `host` field in `config/config.json`:
+```json
+{
+  "development": {
+    "host": "127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436",
+    "username": "yugabyte",
+    "password": "yugabyte",
+    "database": "ysql_sequelize",
+    "port": "5436"
+  }
+}
 ```

--- a/node/sequelize/README.md
+++ b/node/sequelize/README.md
@@ -9,7 +9,7 @@ Install depedencies by running:
 $ npm install
 ```
 
-Create Database
+Ensure the database exists (the `prestart` hook already runs `node ensure-database.js`, but you can double-check manually if you prefer):
 ```
 ysqlsh -c "CREATE DATABASE ysql_sequelize"
 ```
@@ -26,11 +26,17 @@ $ DEBUG=sequelize:* npm start
 
 # Customizing
 
-You can customize the various options by changing the following variables in the file [config/config.json](https://github.com/YugaByte/orm-examples/blob/master/node/sequelize/config/config.json). The descriptions and default values are listed below.
+Most settings come from environment variables (e.g. `YB_HOSTS`, `YB_LOAD_BALANCE`) or the file [config/config.json](https://github.com/YugaByte/orm-examples/blob/master/node/sequelize/config/config.json). The descriptions and default values are listed below.
 
 | Properties    | Description   | Default |
 | ------------- | ------------- | ------- |
 | `host`  | The database host. | `localhost`  |
 | `username` | The username to connect to the database. | `postgres` |
 | `password` | The password to connect to the database. Leave blank for the password. | - |
+| `database` | Database name. | `ysql_sequelize` |
 
+Environment examples:
+```
+export YB_HOSTS=127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436
+export YB_LOAD_BALANCE=any
+```

--- a/node/sequelize/app.js
+++ b/node/sequelize/app.js
@@ -1,6 +1,5 @@
 var createError = require('http-errors');
 var express = require('express');
-var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
 

--- a/node/sequelize/config/config.json
+++ b/node/sequelize/config/config.json
@@ -1,11 +1,11 @@
 {
   "development": {
-    "username": "postgres",
-    "password": "",
+    "username": "yugabyte",
+    "password": "yugabyte",
     "database": "ysql_sequelize",
     "host": "127.0.0.1",
     "dialect": "postgres",
-    "port": "5433"
+    "port": "5436"
   },
   "test": {
     "username": "postgres",

--- a/node/sequelize/config/config.json
+++ b/node/sequelize/config/config.json
@@ -3,7 +3,7 @@
     "username": "yugabyte",
     "password": "yugabyte",
     "database": "ysql_sequelize",
-    "host": "127.0.0.1",
+    "host": "127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436",
     "dialect": "postgres",
     "port": "5436"
   },

--- a/node/sequelize/config/config.json
+++ b/node/sequelize/config/config.json
@@ -3,9 +3,9 @@
     "username": "yugabyte",
     "password": "yugabyte",
     "database": "ysql_sequelize",
-    "host": "127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436",
+    "host": "127.0.0.1:5433,127.0.0.2:5433,127.0.0.3:5433",
     "dialect": "postgres",
-    "port": "5436"
+    "port": "5433"
   },
   "test": {
     "username": "postgres",

--- a/node/sequelize/ensure-database.js
+++ b/node/sequelize/ensure-database.js
@@ -5,6 +5,21 @@
  * Similar to "CREATE DATABASE IF NOT EXISTS" behavior.
  */
 
+const path = require('path');
+
+// Set YugabyteDB smart driver environment variables before loading pg client
+// This ensures load balancing is enabled for database creation
+const ensureEnv = (key, value) => {
+  if (typeof value !== 'undefined' && value !== null && value !== '' && !process.env[key]) {
+    process.env[key] = String(value);
+  }
+};
+
+// Enable load balancing by default
+ensureEnv('PGLOADBALANCE', 'any');
+ensureEnv('PGYBSERVERSREFRESHINTERVAL', '5');
+ensureEnv('PGFAILEDHOSTRECONNECTDELAYSECS', '5');
+
 // Use @yugabytedb/pg if available, otherwise fall back to standard pg
 let Client;
 try {
@@ -12,7 +27,6 @@ try {
 } catch (e) {
   Client = require('pg').Client;
 }
-const path = require('path');
 
 const env = process.env.NODE_ENV || 'development';
 const baseConfig = require(path.join(__dirname, 'config', 'config.json'))[env];
@@ -20,7 +34,7 @@ const baseConfig = require(path.join(__dirname, 'config', 'config.json'))[env];
 // Parse the first host from comma-separated list if needed
 // Otherwise, simply choose one node for write operations
 const parseFirstHost = (hostString) => {
-  if (!hostString) return { host: '127.0.0.1', port: 5436 };
+  if (!hostString) return { host: '127.0.0.1', port: 5433 };
   
   // If comma-separated, take first entry
   const firstEntry = hostString.split(',')[0].trim();
@@ -38,11 +52,11 @@ const parseFirstHost = (hostString) => {
 let host, port;
 if (process.env.PGHOST) {
   host = process.env.PGHOST;
-  port = process.env.PGPORT ? Number(process.env.PGPORT) : 5436;
+  port = process.env.PGPORT ? Number(process.env.PGPORT) : 5433;
 } else {
   const parsed = parseFirstHost(baseConfig.host);
   host = parsed.host;
-  port = parsed.port || Number(baseConfig.port) || 5436;
+  port = parsed.port || Number(baseConfig.port) || 5433;
 }
 
 const database = process.env.PGDATABASE || baseConfig.database || 'ysql_sequelize';

--- a/node/sequelize/ensure-database.js
+++ b/node/sequelize/ensure-database.js
@@ -17,46 +17,20 @@ const path = require('path');
 const env = process.env.NODE_ENV || 'development';
 const baseConfig = require(path.join(__dirname, 'config', 'config.json'))[env];
 
-// Parse PGHOSTS (custom, comma-separated) or PGHOST (standard, single host) or use config defaults
-const parseHosts = (rawHosts) => {
-  if (!rawHosts) {
-    return [{ host: baseConfig.host || '127.0.0.1', port: Number(baseConfig.port) || 5436 }];
-  }
-  return rawHosts
-    .split(',')
-    .map(entry => entry.trim())
-    .filter(Boolean)
-    .map(entry => {
-      const [host, port = baseConfig.port || '5436'] = entry.split(':');
-      return { host, port: Number(port) };
-    });
-};
-
-const HOSTS = (() => {
-  // Check for PGHOSTS first (comma-separated list), then PGHOST (single host)
-  if (process.env.PGHOSTS) {
-    return parseHosts(process.env.PGHOSTS);
-  }
-  
-  if (process.env.PGHOST) {
-    const port = process.env.PGPORT || baseConfig.port || '5436';
-    return parseHosts(`${process.env.PGHOST}:${port}`);
-  }
-  
-  // Fall back to config
-  return parseHosts(`${baseConfig.host || '127.0.0.1'}:${baseConfig.port || 5436}`);
-})();
+// Determine the host and port to connect to
+// Priority: PGHOST (standard PostgreSQL) > config.json
+const host = process.env.PGHOST || baseConfig.host || '127.0.0.1';
+const port = process.env.PGPORT ? Number(process.env.PGPORT) : (Number(baseConfig.port) || 5436);
 
 const database = process.env.PGDATABASE || baseConfig.database || 'ysql_sequelize';
 const username = process.env.PGUSER || baseConfig.username || 'yugabyte';
 const password = process.env.PGPASSWORD || baseConfig.password || 'yugabyte';
 
 async function ensureDatabase() {
-  // Try to connect to the first host using the default 'yugabyte' database
-  const primaryHost = HOSTS[0];
+  // Try to connect using the default 'yugabyte' database
   const adminClient = new Client({
-    host: primaryHost.host,
-    port: primaryHost.port,
+    host: host,
+    port: port,
     user: username,
     password: password,
     database: 'yugabyte',
@@ -64,7 +38,7 @@ async function ensureDatabase() {
 
   try {
     await adminClient.connect();
-    console.log(`Connected to ${HOSTS[0].host}:${HOSTS[0].port}`);
+    console.log(`Connected to ${host}:${port}`);
 
     // Check if database exists
     const result = await adminClient.query(

--- a/node/sequelize/ensure-database.js
+++ b/node/sequelize/ensure-database.js
@@ -17,10 +17,33 @@ const path = require('path');
 const env = process.env.NODE_ENV || 'development';
 const baseConfig = require(path.join(__dirname, 'config', 'config.json'))[env];
 
+// Parse the first host from comma-separated list if needed
+// Otherwise, simply choose one node for write operations
+const parseFirstHost = (hostString) => {
+  if (!hostString) return { host: '127.0.0.1', port: 5436 };
+  
+  // If comma-separated, take first entry
+  const firstEntry = hostString.split(',')[0].trim();
+  
+  // Parse host:port
+  const [host, port] = firstEntry.split(':');
+  return {
+    host: host,
+    port: port ? Number(port) : null
+  };
+};
+
 // Determine the host and port to connect to
 // Priority: PGHOST (standard PostgreSQL) > config.json
-const host = process.env.PGHOST || baseConfig.host || '127.0.0.1';
-const port = process.env.PGPORT ? Number(process.env.PGPORT) : (Number(baseConfig.port) || 5436);
+let host, port;
+if (process.env.PGHOST) {
+  host = process.env.PGHOST;
+  port = process.env.PGPORT ? Number(process.env.PGPORT) : 5436;
+} else {
+  const parsed = parseFirstHost(baseConfig.host);
+  host = parsed.host;
+  port = parsed.port || Number(baseConfig.port) || 5436;
+}
 
 const database = process.env.PGDATABASE || baseConfig.database || 'ysql_sequelize';
 const username = process.env.PGUSER || baseConfig.username || 'yugabyte';

--- a/node/sequelize/ensure-database.js
+++ b/node/sequelize/ensure-database.js
@@ -48,7 +48,7 @@ const parseFirstHost = (hostString) => {
 };
 
 // Determine the host and port to connect to
-// Priority: PGHOST (standard PostgreSQL) > config.json
+// Priority: PGHOST/PGPORT env vars > config.json
 let host, port;
 if (process.env.PGHOST) {
   host = process.env.PGHOST;
@@ -56,7 +56,8 @@ if (process.env.PGHOST) {
 } else {
   const parsed = parseFirstHost(baseConfig.host);
   host = parsed.host;
-  port = parsed.port || Number(baseConfig.port) || 5433;
+  // PGPORT env var takes precedence over parsed or config port
+  port = process.env.PGPORT ? Number(process.env.PGPORT) : (parsed.port || Number(baseConfig.port) || 5433);
 }
 
 const database = process.env.PGDATABASE || baseConfig.database || 'ysql_sequelize';

--- a/node/sequelize/ensure-database.js
+++ b/node/sequelize/ensure-database.js
@@ -17,7 +17,7 @@ const path = require('path');
 const env = process.env.NODE_ENV || 'development';
 const baseConfig = require(path.join(__dirname, 'config', 'config.json'))[env];
 
-// Parse YB_HOSTS or use config defaults
+// Parse PGHOSTS (custom, comma-separated) or PGHOST (standard, single host) or use config defaults
 const parseHosts = (rawHosts) => {
   if (!rawHosts) {
     return [{ host: baseConfig.host || '127.0.0.1', port: Number(baseConfig.port) || 5436 }];
@@ -32,13 +32,24 @@ const parseHosts = (rawHosts) => {
     });
 };
 
-const HOSTS = process.env.YB_HOSTS 
-  ? parseHosts(process.env.YB_HOSTS)
-  : parseHosts(`${baseConfig.host || '127.0.0.1'}:${baseConfig.port || 5436}`);
+const HOSTS = (() => {
+  // Check for PGHOSTS first (comma-separated list), then PGHOST (single host)
+  if (process.env.PGHOSTS) {
+    return parseHosts(process.env.PGHOSTS);
+  }
+  
+  if (process.env.PGHOST) {
+    const port = process.env.PGPORT || baseConfig.port || '5436';
+    return parseHosts(`${process.env.PGHOST}:${port}`);
+  }
+  
+  // Fall back to config
+  return parseHosts(`${baseConfig.host || '127.0.0.1'}:${baseConfig.port || 5436}`);
+})();
 
-const database = baseConfig.database || 'ysql_sequelize';
-const username = baseConfig.username || 'yugabyte';
-const password = baseConfig.password || 'yugabyte';
+const database = process.env.PGDATABASE || baseConfig.database || 'ysql_sequelize';
+const username = process.env.PGUSER || baseConfig.username || 'yugabyte';
+const password = process.env.PGPASSWORD || baseConfig.password || 'yugabyte';
 
 async function ensureDatabase() {
   // Try to connect to the first host using the default 'yugabyte' database

--- a/node/sequelize/ensure-database.js
+++ b/node/sequelize/ensure-database.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+/**
+ * Ensures the database exists before starting the application.
+ * Similar to "CREATE DATABASE IF NOT EXISTS" behavior.
+ */
+
+// Use @yugabytedb/pg if available, otherwise fall back to standard pg
+let Client;
+try {
+  Client = require('@yugabytedb/pg').Client;
+} catch (e) {
+  Client = require('pg').Client;
+}
+const path = require('path');
+
+const env = process.env.NODE_ENV || 'development';
+const baseConfig = require(path.join(__dirname, 'config', 'config.json'))[env];
+
+// Parse YB_HOSTS or use config defaults
+const parseHosts = (rawHosts) => {
+  if (!rawHosts) {
+    return [{ host: baseConfig.host || '127.0.0.1', port: Number(baseConfig.port) || 5436 }];
+  }
+  return rawHosts
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(Boolean)
+    .map(entry => {
+      const [host, port = baseConfig.port || '5436'] = entry.split(':');
+      return { host, port: Number(port) };
+    });
+};
+
+const HOSTS = process.env.YB_HOSTS 
+  ? parseHosts(process.env.YB_HOSTS)
+  : parseHosts(`${baseConfig.host || '127.0.0.1'}:${baseConfig.port || 5436}`);
+
+const database = baseConfig.database || 'ysql_sequelize';
+const username = baseConfig.username || 'yugabyte';
+const password = baseConfig.password || 'yugabyte';
+
+async function ensureDatabase() {
+  // Try to connect to the first host using the default 'yugabyte' database
+  const primaryHost = HOSTS[0];
+  const adminClient = new Client({
+    host: primaryHost.host,
+    port: primaryHost.port,
+    user: username,
+    password: password,
+    database: 'yugabyte',
+  });
+
+  try {
+    await adminClient.connect();
+    console.log(`Connected to ${HOSTS[0].host}:${HOSTS[0].port}`);
+
+    // Check if database exists
+    const result = await adminClient.query(
+      `SELECT 1 FROM pg_database WHERE datname = $1`,
+      [database]
+    );
+
+    if (result.rows.length === 0) {
+      // Database doesn't exist, create it
+      console.log(`Creating database "${database}"...`);
+      // 
+      await adminClient.query(`CREATE DATABASE ${database}`);
+      console.log(`Database "${database}" created successfully`);
+    } else {
+      console.log(`Database "${database}" already exists`);
+    }
+
+    await adminClient.end();
+    return true;
+  } catch (error) {
+    console.error(`Error ensuring database: ${error.message}`);
+    await adminClient.end().catch(() => {});
+    return false;
+  }
+}
+
+// Run if called directly
+if (require.main === module) {
+  ensureDatabase()
+    .then(success => {
+      process.exit(success ? 0 : 1);
+    })
+    .catch(error => {
+      console.error('Fatal error:', error);
+      process.exit(1);
+    });
+}
+
+module.exports = { ensureDatabase };
+

--- a/node/sequelize/models/index.js
+++ b/node/sequelize/models/index.js
@@ -8,17 +8,16 @@ require('dotenv').config();
  * Configuration via environment variables (in order of precedence):
  * 
  * 1. Standard PostgreSQL variables:
- *    - PGHOST: Single database host (e.g., "127.0.0.1")
+ *    - PGHOST: Database host (e.g., "127.0.0.1")
  *    - PGPORT: Database port (default: 5436)
  *    - PGUSER: Database user (default: yugabyte)
  *    - PGPASSWORD: Database password (default: yugabyte)
  *    - PGDATABASE: Database name (default: ysql_sequelize)
  * 
- * 2. Custom multi-host variable (for YugabyteDB load balancing):
- *    - PGHOSTS: Comma-separated list of host:port (e.g., "127.0.0.1:5436,127.0.0.2:5436")
- *               Note: This is a CUSTOM variable (not standard PostgreSQL) needed for YugabyteDB's 
- *               topology-aware load balancing across multiple nodes. Standard PostgreSQL's PGHOST 
- *               only supports a single host. PGHOSTS takes precedence over PGHOST when set.
+ * 2. Multi-host configuration via config.json:
+ *    - For YugabyteDB multi-node load balancing, specify multiple hosts in config.json:
+ *      "host": "127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436"
+ *    - Environment variable PGHOST takes precedence over config.json
  * 
  * 3. YugabyteDB load balancing variables (extensions to standard PostgreSQL):
  *    - PGLOADBALANCE: Read load balancing mode (any, only-primary, prefer-primary, prefer-rr, only-rr)
@@ -64,18 +63,15 @@ const parseHosts = rawHosts =>
     });
 
 const HOSTS = (() => {
-  // Check for PGHOSTS first (comma-separated list), then PGHOST (single host)
-  if (process.env.PGHOSTS) {
-    return parseHosts(process.env.PGHOSTS);
-  }
-  
+  // Priority: PGHOST env var > config.json > default 3-node setup
   if (process.env.PGHOST) {
     const port = process.env.PGPORT || DEFAULT_YB_PORT;
     return parseHosts(`${process.env.PGHOST}:${port}`);
   }
 
   if (baseConfig.host) {
-    // Allow config.json to specify a single host or host:port entry.
+    // config.json can specify single host or comma-separated multi-host for load balancing
+    // Examples: "127.0.0.1" or "127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436"
     const hostSpec =
       baseConfig.port && !String(baseConfig.host).includes(':')
         ? `${baseConfig.host}:${baseConfig.port}`

--- a/node/sequelize/models/index.js
+++ b/node/sequelize/models/index.js
@@ -56,12 +56,13 @@ const parseHosts = rawHosts =>
     });
 
 const HOSTS = (() => {
-  // Priority: PGHOST env var > config.json > default 3-node setup
+  // Priority: PGHOST/PGPORT env vars > config.json > default 3-node setup
   if (process.env.PGHOST) {
     const port = process.env.PGPORT || DEFAULT_YB_PORT;
     return parseHosts(`${process.env.PGHOST}:${port}`);
   }
 
+  let hosts;
   if (baseConfig.host) {
     // config.json can specify single host or comma-separated multi-host for load balancing
     // Examples: "127.0.0.1" or "127.0.0.1:5433,127.0.0.2:5433,127.0.0.3:5433"
@@ -69,11 +70,19 @@ const HOSTS = (() => {
       baseConfig.port && !String(baseConfig.host).includes(':')
         ? `${baseConfig.host}:${baseConfig.port}`
         : baseConfig.host;
-    return parseHosts(hostSpec);
+    hosts = parseHosts(hostSpec);
+  } else {
+    // Default to the local 3-node setup (127.0.0.[1-3]:5433) provisioned in docs.
+    hosts = parseHosts('127.0.0.1:5433,127.0.0.2:5433,127.0.0.3:5433');
   }
 
-  // Default to the local 3-node setup (127.0.0.[1-3]:5433) provisioned in docs.
-  return parseHosts('127.0.0.1:5433,127.0.0.2:5433,127.0.0.3:5433');
+  // PGPORT env var overrides all port values
+  if (process.env.PGPORT) {
+    const overridePort = Number(process.env.PGPORT);
+    hosts = hosts.map(h => ({ ...h, port: overridePort }));
+  }
+
+  return hosts;
 })();
 
 // Load balance mode: any, prefer-primary, prefer-rr, only-primary, only-rr

--- a/node/sequelize/models/index.js
+++ b/node/sequelize/models/index.js
@@ -20,14 +20,11 @@ require('dotenv').config();
  *    - Environment variable PGHOST takes precedence over config.json
  * 
  * 3. YugabyteDB load balancing variables (extensions to standard PostgreSQL):
- *    - PGLOADBALANCE: Read load balancing mode (any, only-primary, prefer-primary, prefer-rr, only-rr)
- *    - PGWRITELOADBALANCE: Sets the loadBalance property for write connections (default: only-primary)
- *                          Note: This is NOT a standard YugabyteDB environment variable, it's a custom
- *                          extension for this example to separately control write load balancing behavior.
- *    - PGTOPOLOGYKEYS: Optional topology awareness keys
- *    - PGFALLBACKTOTOPOLOGYKEYSONLY: Optional fallback to topology keys only (default: false)
- *    - PGYBSERVERSREFRESHINTERVAL: Optional metadata refresh interval in seconds (default: 5)
- *    - PGFAILEDHOSTRECONNECTDELAYSECS: Optional reconnect delay in seconds (default: 5)
+ *    - PGLOADBALANCE: Load balancing mode (any, only-primary, prefer-primary, prefer-rr, only-rr)
+ *    - PGTOPOLOGYKEYS: Topology awareness keys (e.g., "cloud.region.zone")
+ *    - PGFALLBACKTOTOPOLOGYKEYSONLY: Fallback to topology keys only (default: false)
+ *    - PGYBSERVERSREFRESHINTERVAL: Metadata refresh interval in seconds (default: 5)
+ *    - PGFAILEDHOSTRECONNECTDELAYSECS: Reconnect delay in seconds (default: 5)
  */
 
 const fs = require('fs');
@@ -84,13 +81,12 @@ const HOSTS = (() => {
 })();
 
 // Load balance mode options: 
-// - 'any': Uses all nodes, least-loaded selection works immediately (best for reliability)
-// - 'prefer-rr': Tries read replicas first, falls back to primary if RR unavailable
-// - 'only-rr': Only uses read replicas (requires metadata refresh, may fail on first connection)
-// - 'only-primary': Only uses primary nodes (for writes)
-// - 'prefer-primary': Prefers primary, falls back to RR
+// - 'any': Uses all nodes, least-loaded selection (best for reliability)
+// - 'prefer-rr': Tries read replicas first, falls back to primary
+// - 'only-rr': Only uses read replicas
+// - 'only-primary': Only uses primary nodes
+// - 'prefer-primary': Prefers primary, falls back to read replicas
 const READ_LOAD_BALANCE_MODE = process.env.PGLOADBALANCE || "any";
-const WRITE_LOAD_BALANCE_MODE = process.env.PGWRITELOADBALANCE || "only-primary";
 
 // Optional topology awareness and driver tuning (only set if needed)
 const TOPOLOGY_KEYS = process.env.PGTOPOLOGYKEYS || "";
@@ -99,7 +95,7 @@ const SERVER_REFRESH_INTERVAL = process.env.PGYBSERVERSREFRESHINTERVAL ? Number(
 const FAILED_HOST_RECONNECT_DELAY_SECS = process.env.PGFAILEDHOSTRECONNECTDELAYSECS ? Number(process.env.PGFAILEDHOSTRECONNECTDELAYSECS) : 5;
 
 // Utility function to set environment variables if not already set
-// The @yugabytedb/pg driver reads these directly from process.env/environment variables
+// The @yugabytedb/pg driver reads these directly from process.env
 const ensureEnv = (key, value) => {
   if (
     typeof value !== 'undefined' &&
@@ -124,19 +120,6 @@ ensureEnv(
   FAILED_HOST_RECONNECT_DELAY_SECS,
 );
 
-const SMART_DRIVER_DEFAULTS = {
-  ...(TOPOLOGY_KEYS ? { topologyKeys: TOPOLOGY_KEYS } : {}),
-  ...(FALLBACK_TO_TOPOLOGY_KEYS_ONLY
-    ? { fallbackToTopologyKeysOnly: true }
-    : {}),
-  ...(Number.isFinite(SERVER_REFRESH_INTERVAL)
-    ? { ybServersRefreshInterval: SERVER_REFRESH_INTERVAL }
-    : {}),
-  ...(Number.isFinite(FAILED_HOST_RECONNECT_DELAY_SECS)
-    ? { failedHostReconnectDelaySecs: FAILED_HOST_RECONNECT_DELAY_SECS }
-    : {}),
-};
-
 function createSmartSequelizeInstance() {
   const [primaryHost] = HOSTS;
 
@@ -151,19 +134,13 @@ function createSmartSequelizeInstance() {
       ? console.log
       : false;
 
-  // Use single connection with YugabyteDB smart driver for automatic load balancing
-  // The driver will discover all nodes and distribute queries automatically
+  // Use YugabyteDB smart driver for automatic load balancing
+  // Driver reads config from process.env/environment variables (set via ensureEnv) and discovers all nodes
   return new Sequelize(database, username, password, {
     host: primaryHost.host,
     port: primaryHost.port,
     dialect: 'postgres',
     logging: loggingType,
-    // YugabyteDB smart driver properties must be at top level, not in dialectOptions
-    loadBalance: READ_LOAD_BALANCE_MODE,
-    topologyKeys: TOPOLOGY_KEYS,
-    fallbackToTopologyKeysOnly: FALLBACK_TO_TOPOLOGY_KEYS_ONLY,
-    ybServersRefreshInterval: SERVER_REFRESH_INTERVAL,
-    failedHostReconnectDelaySecs: FAILED_HOST_RECONNECT_DELAY_SECS,
     pool: {
       max: 10,
       min: 2,
@@ -176,7 +153,7 @@ function createSmartSequelizeInstance() {
   });
 }
 
-// Alternative: Using Connection String
+// Alternative method: Using Connection String
 function createSequelizeWithConnectionString() {
   const username = process.env.PGUSER || baseConfig.username || 'yugabyte';
   const password = process.env.PGPASSWORD || (baseConfig.password && baseConfig.password !== '' ? baseConfig.password : 'yugabyte');
@@ -197,8 +174,6 @@ function createSequelizeWithConnectionString() {
   const logLevel = (process.env.LOG_LEVEL || '').toLowerCase();
   const loggingType = logLevel === 'silly' ? console.log : false;
   
-  console.log(`Connection string (sanitized): postgres://${username}:****@${host}:${port}/${database}?loadBalance=${READ_LOAD_BALANCE_MODE}...`);
-  
   return new Sequelize(connectionString, {
     dialect: 'postgres',
     logging: loggingType,
@@ -216,7 +191,7 @@ function createSequelizeWithConnectionString() {
 
 // Choose which method to use:
 const sequelize = createSmartSequelizeInstance();
-// Uncomment to use connection string instead:
+// Alternative: Uncomment to use connection string instead:
 // const sequelize = createSequelizeWithConnectionString();
 
 fs

--- a/node/sequelize/models/index.js
+++ b/node/sequelize/models/index.js
@@ -1,29 +1,196 @@
+require('dotenv').config();
+
 'use strict';
+
+/**
+ * Smart‑driver aware Sequelize bootstrap for YugabyteDB.
+ *
+ * Load balancing configuration via environment variables:
+ * - YB_HOSTS: Comma-separated list of host:port (e.g., "127.0.0.1:5436,127.0.0.2:5436")
+ * - YB_LOAD_BALANCE: Read load balancing mode (any, only-primary, prefer-primary, prefer-rr, only-rr)
+ * - YB_WRITE_LOAD_BALANCE: Write load balancing mode (default: only-primary)
+ * - YB_TOPOLOGY_KEYS: Optional topology awareness keys
+ * - YB_SERVERS_REFRESH_INTERVAL: Optional metadata refresh interval (default: 5s)
+ * - YB_FAILED_HOST_RECONNECT_DELAY_SECS: Optional reconnect delay (default: 5s)
+ *
+ * These are bridged to @yugabytedb/pg driver via PG* environment variables.
+ */
 
 const fs = require('fs');
 const path = require('path');
-const Sequelize = require('sequelize-yugabytedb');
+const sequelizePkg = require('sequelize-yugabytedb');
+
+const { Sequelize } = sequelizePkg;
+
 const basename = path.basename(__filename);
 const env = process.env.NODE_ENV || 'development';
-const config = require(__dirname + '/../config/config.json')[env];
+const baseConfig = require(path.join(__dirname, '..', 'config', 'config.json'))[
+  env
+];
+
 const db = {};
 
-let sequelize;
-if (config.use_env_variable) {
-  sequelize = new Sequelize(process.env[config.use_env_variable], config);
-} else {
-  sequelize = new Sequelize(config.database, config.username, config.password, config);
+const DEFAULT_YB_PORT = 5436;
+
+const normalizeBooleanEnv = value =>
+  typeof value === 'string' ? value.toLowerCase() === 'true' : Boolean(value);
+
+const parseHosts = rawHosts =>
+  rawHosts
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(Boolean)
+    .map(entry => {
+      const [host, rawPort] = entry.split(':');
+      return {
+        host,
+        port: Number(rawPort) || DEFAULT_YB_PORT,
+      };
+    });
+
+const HOSTS = (() => {
+  if (process.env.YB_HOSTS) {
+    return parseHosts(process.env.YB_HOSTS);
+  }
+
+  if (baseConfig.host) {
+    // Allow config.json to specify a single host or host:port entry.
+    const hostSpec =
+      baseConfig.port && !String(baseConfig.host).includes(':')
+        ? `${baseConfig.host}:${baseConfig.port}`
+        : baseConfig.host;
+    return parseHosts(hostSpec);
+  }
+
+  // Default to the local 3-node setup (127.0.0.[1-3]:5436) provisioned in docs.
+  return parseHosts('127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436');
+})();
+
+// Load balance mode options:
+// - 'any': Uses all nodes, least-loaded selection works immediately (best for reliability)
+// - 'prefer-rr': Tries read replicas first, falls back to primary if RR unavailable
+// - 'only-rr': Only uses read replicas (requires metadata refresh, may fail on first connection)
+// - 'only-primary': Only uses primary nodes (for writes)
+// - 'prefer-primary': Prefers primary, falls back to RR
+const READ_LOAD_BALANCE_MODE = "any";
+const WRITE_LOAD_BALANCE_MODE = "only-primary";
+
+// Optional topology awareness and driver tuning (only set if needed)
+const TOPOLOGY_KEYS = "";
+const FALLBACK_TO_TOPOLOGY_KEYS_ONLY = false;
+const SERVER_REFRESH_INTERVAL = 5;
+const FAILED_HOST_RECONNECT_DELAY_SECS = 5;
+
+const ensureEnv = (key, value) => {
+  if (
+    typeof value !== 'undefined' &&
+    value !== null &&
+    value !== '' &&
+    !process.env[key]
+  ) {
+    process.env[key] = String(value);
+  }
+};
+
+
+// These environment varibales are passed to the @yugabytedb/pg driver.
+ensureEnv('PGLOADBALANCE', READ_LOAD_BALANCE_MODE);
+ensureEnv('PGTOPOLOGYKEYS', TOPOLOGY_KEYS);
+ensureEnv(
+  'PGFALLBACKTOTOPOLOGYKEYSONLY', 
+  FALLBACK_TO_TOPOLOGY_KEYS_ONLY ? 'true' : undefined,
+);
+ensureEnv('PGYBSERVERSREFRESHINTERVAL', SERVER_REFRESH_INTERVAL);
+ensureEnv(
+  'PGFAILEDHOSTRECONNECTDELAYSECS',
+  FAILED_HOST_RECONNECT_DELAY_SECS,
+);
+
+const SMART_DRIVER_DEFAULTS = {
+  ...(TOPOLOGY_KEYS ? { topologyKeys: TOPOLOGY_KEYS } : {}),
+  ...(FALLBACK_TO_TOPOLOGY_KEYS_ONLY
+    ? { fallbackToTopologyKeysOnly: true }
+    : {}),
+  ...(Number.isFinite(SERVER_REFRESH_INTERVAL)
+    ? { ybServersRefreshInterval: SERVER_REFRESH_INTERVAL }
+    : {}),
+  ...(Number.isFinite(FAILED_HOST_RECONNECT_DELAY_SECS)
+    ? { failedHostReconnectDelaySecs: FAILED_HOST_RECONNECT_DELAY_SECS }
+    : {}),
+};
+
+function createSmartSequelizeInstance() {
+  const [primaryHost] = HOSTS;
+
+  const username = baseConfig.username || 'yugabyte';
+  const password = baseConfig.password || 'yugabyte';
+  const database = baseConfig.database || 'ysql_sequelize';
+
+  const logLevel = (process.env.LOG_LEVEL || '').toLowerCase();
+  
+  
+  // I'll remove this afterwards.
+  const loggingType =
+    logLevel === 'silly'
+      ? console.log
+      : false;
+
+  // Use all hosts for read replicas (load balancing will handle node selection)
+  const readReplicas = HOSTS;
+
+  const buildConnectionConfig = ({ host, port }, loadBalanceValue) => ({
+    host,
+    port,
+    username,
+    password,
+    database,
+    loadBalance: loadBalanceValue,
+    ...SMART_DRIVER_DEFAULTS,
+  });
+
+  return new Sequelize({
+    dialect: 'postgres',
+    database,
+    username,
+    password,
+    logging: loggingType,
+    replication: {
+      write: buildConnectionConfig(primaryHost, WRITE_LOAD_BALANCE_MODE),
+      read: readReplicas.map(node =>
+        buildConnectionConfig(node, READ_LOAD_BALANCE_MODE),
+      ),
+    },
+    pool: {
+      max: 10,
+      min: 2,
+      idle: 10000,
+      acquire: 30000,
+    },
+    dialectOptions: {
+      statement_timeout: 60000,
+    },
+  });
 }
+
+const sequelize = createSmartSequelizeInstance();
 
 fs
   .readdirSync(__dirname)
   .filter(file => {
-    return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js');
+    return (
+      file.indexOf('.') !== 0 &&
+      file !== basename &&
+      file.slice(-3) === '.js'
+    );
   })
   .forEach(file => {
-    // const model = sequelize['import'](path.join(__dirname, file)); 
-    //REASON of not using above line of code: sequelize.import function has been depreciated. link: https://github.com/sequelize/sequelize/pull/12175
-    const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);
+    // const model = sequelize['import'](path.join(__dirname, file));
+    // REASON for not using above line of code: sequelize.import has been
+    // deprecated. See: https://github.com/sequelize/sequelize/pull/12175
+    const model = require(path.join(__dirname, file))(
+      sequelize,
+      sequelizePkg.DataTypes,
+    );
     db[model.name] = model;
   });
 

--- a/node/sequelize/models/index.js
+++ b/node/sequelize/models/index.js
@@ -5,15 +5,26 @@ require('dotenv').config();
 /**
  * Smart‑driver aware Sequelize bootstrap for YugabyteDB.
  *
- * Load balancing configuration via environment variables:
- * - YB_HOSTS: Comma-separated list of host:port (e.g., "127.0.0.1:5436,127.0.0.2:5436")
- * - YB_LOAD_BALANCE: Read load balancing mode (any, only-primary, prefer-primary, prefer-rr, only-rr)
- * - YB_WRITE_LOAD_BALANCE: Write load balancing mode (default: only-primary)
- * - YB_TOPOLOGY_KEYS: Optional topology awareness keys
- * - YB_SERVERS_REFRESH_INTERVAL: Optional metadata refresh interval (default: 5s)
- * - YB_FAILED_HOST_RECONNECT_DELAY_SECS: Optional reconnect delay (default: 5s)
- *
- * These are bridged to @yugabytedb/pg driver via PG* environment variables.
+ * Configuration via environment variables (in order of precedence):
+ * 
+ * 1. Standard PostgreSQL variables:
+ *    - PGHOST: Single database host (e.g., "127.0.0.1")
+ *    - PGPORT: Database port (default: 5436)
+ *    - PGUSER: Database user (default: yugabyte)
+ *    - PGPASSWORD: Database password (default: yugabyte)
+ *    - PGDATABASE: Database name (default: ysql_sequelize)
+ * 
+ * 2. Custom multi-host variable (for load balancing):
+ *    - PGHOSTS: Comma-separated list of host:port (e.g., "127.0.0.1:5436,127.0.0.2:5436")
+ *               Note: This is a custom variable, not standard PostgreSQL. Takes precedence over PGHOST.
+ * 
+ * 3. YugabyteDB load balancing variables (extensions to standard PostgreSQL):
+ *    - PGLOADBALANCE: Read load balancing mode (any, only-primary, prefer-primary, prefer-rr, only-rr)
+ *    - PGWRITELOADBALANCE: Write load balancing mode (default: only-primary)
+ *    - PGTOPOLOGYKEYS: Optional topology awareness keys
+ *    - PGFALLBACKTOTOPOLOGYKEYSONLY: Optional fallback to topology keys only (default: false)
+ *    - PGYBSERVERSREFRESHINTERVAL: Optional metadata refresh interval in seconds (default: 5)
+ *    - PGFAILEDHOSTRECONNECTDELAYSECS: Optional reconnect delay in seconds (default: 5)
  */
 
 const fs = require('fs');
@@ -49,8 +60,14 @@ const parseHosts = rawHosts =>
     });
 
 const HOSTS = (() => {
-  if (process.env.YB_HOSTS) {
-    return parseHosts(process.env.YB_HOSTS);
+  // Check for PGHOSTS first (comma-separated list), then PGHOST (single host)
+  if (process.env.PGHOSTS) {
+    return parseHosts(process.env.PGHOSTS);
+  }
+  
+  if (process.env.PGHOST) {
+    const port = process.env.PGPORT || DEFAULT_YB_PORT;
+    return parseHosts(`${process.env.PGHOST}:${port}`);
   }
 
   if (baseConfig.host) {
@@ -66,45 +83,20 @@ const HOSTS = (() => {
   return parseHosts('127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436');
 })();
 
-// Load balance mode options:
+// Load balance mode options: 
 // - 'any': Uses all nodes, least-loaded selection works immediately (best for reliability)
 // - 'prefer-rr': Tries read replicas first, falls back to primary if RR unavailable
 // - 'only-rr': Only uses read replicas (requires metadata refresh, may fail on first connection)
 // - 'only-primary': Only uses primary nodes (for writes)
 // - 'prefer-primary': Prefers primary, falls back to RR
-const READ_LOAD_BALANCE_MODE = "any";
-const WRITE_LOAD_BALANCE_MODE = "only-primary";
+const READ_LOAD_BALANCE_MODE = process.env.PGLOADBALANCE || "any";
+const WRITE_LOAD_BALANCE_MODE = process.env.PGWRITELOADBALANCE || "only-primary";
 
 // Optional topology awareness and driver tuning (only set if needed)
-const TOPOLOGY_KEYS = "";
-const FALLBACK_TO_TOPOLOGY_KEYS_ONLY = false;
-const SERVER_REFRESH_INTERVAL = 5;
-const FAILED_HOST_RECONNECT_DELAY_SECS = 5;
-
-const ensureEnv = (key, value) => {
-  if (
-    typeof value !== 'undefined' &&
-    value !== null &&
-    value !== '' &&
-    !process.env[key]
-  ) {
-    process.env[key] = String(value);
-  }
-};
-
-
-// These environment varibales are passed to the @yugabytedb/pg driver.
-ensureEnv('PGLOADBALANCE', READ_LOAD_BALANCE_MODE);
-ensureEnv('PGTOPOLOGYKEYS', TOPOLOGY_KEYS);
-ensureEnv(
-  'PGFALLBACKTOTOPOLOGYKEYSONLY', 
-  FALLBACK_TO_TOPOLOGY_KEYS_ONLY ? 'true' : undefined,
-);
-ensureEnv('PGYBSERVERSREFRESHINTERVAL', SERVER_REFRESH_INTERVAL);
-ensureEnv(
-  'PGFAILEDHOSTRECONNECTDELAYSECS',
-  FAILED_HOST_RECONNECT_DELAY_SECS,
-);
+const TOPOLOGY_KEYS = process.env.PGTOPOLOGYKEYS || "";
+const FALLBACK_TO_TOPOLOGY_KEYS_ONLY = normalizeBooleanEnv(process.env.PGFALLBACKTOTOPOLOGYKEYSONLY) || false;
+const SERVER_REFRESH_INTERVAL = process.env.PGYBSERVERSREFRESHINTERVAL ? Number(process.env.PGYBSERVERSREFRESHINTERVAL) : 5;
+const FAILED_HOST_RECONNECT_DELAY_SECS = process.env.PGFAILEDHOSTRECONNECTDELAYSECS ? Number(process.env.PGFAILEDHOSTRECONNECTDELAYSECS) : 5;
 
 const SMART_DRIVER_DEFAULTS = {
   ...(TOPOLOGY_KEYS ? { topologyKeys: TOPOLOGY_KEYS } : {}),
@@ -122,14 +114,12 @@ const SMART_DRIVER_DEFAULTS = {
 function createSmartSequelizeInstance() {
   const [primaryHost] = HOSTS;
 
-  const username = baseConfig.username || 'yugabyte';
-  const password = baseConfig.password || 'yugabyte';
-  const database = baseConfig.database || 'ysql_sequelize';
+  const username = process.env.PGUSER || baseConfig.username || 'yugabyte';
+  const password = process.env.PGPASSWORD || (baseConfig.password && baseConfig.password !== '' ? baseConfig.password : 'yugabyte');
+  const database = process.env.PGDATABASE || baseConfig.database || 'ysql_sequelize';
 
   const logLevel = (process.env.LOG_LEVEL || '').toLowerCase();
   
-  
-  // I'll remove this afterwards.
   const loggingType =
     logLevel === 'silly'
       ? console.log
@@ -172,7 +162,53 @@ function createSmartSequelizeInstance() {
   });
 }
 
+/**
+ * Alternative: Using Connection String
+ * 
+ * This creates a simpler single-connection instance using a PostgreSQL connection URL.
+ * Load balancing parameters are passed as query parameters in the URL.
+ */
+function createSequelizeWithConnectionString() {
+  const username = process.env.PGUSER || baseConfig.username || 'yugabyte';
+  const password = process.env.PGPASSWORD || (baseConfig.password && baseConfig.password !== '' ? baseConfig.password : 'yugabyte');
+  const database = process.env.PGDATABASE || baseConfig.database || 'ysql_sequelize';
+  
+  // Use first host for simple connection
+  const { host, port } = HOSTS[0];
+  
+  // Build connection string with load balance parameters
+  const connectionString = 
+    `postgres://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${host}:${port}/${database}` +
+    `?loadBalance=${READ_LOAD_BALANCE_MODE}` +
+    (TOPOLOGY_KEYS ? `&topologyKeys=${encodeURIComponent(TOPOLOGY_KEYS)}` : '') +
+    `&ybServersRefreshInterval=${SERVER_REFRESH_INTERVAL}` +
+    `&failedHostReconnectDelaySecs=${FAILED_HOST_RECONNECT_DELAY_SECS}` +
+    (FALLBACK_TO_TOPOLOGY_KEYS_ONLY ? `&fallbackToTopologyKeysOnly=true` : '');
+  
+  const logLevel = (process.env.LOG_LEVEL || '').toLowerCase();
+  const loggingType = logLevel === 'silly' ? console.log : false;
+  
+  console.log(`Connection string (sanitized): postgres://${username}:****@${host}:${port}/${database}?loadBalance=${READ_LOAD_BALANCE_MODE}...`);
+  
+  return new Sequelize(connectionString, {
+    dialect: 'postgres',
+    logging: loggingType,
+    pool: {
+      max: 10,
+      min: 2,
+      idle: 10000,
+      acquire: 30000,
+    },
+    dialectOptions: {
+      statement_timeout: 60000,
+    },
+  });
+}
+
+// Choose which method to use:
 const sequelize = createSmartSequelizeInstance();
+// Uncomment to use connection string instead:
+// const sequelize = createSequelizeWithConnectionString();
 
 fs
   .readdirSync(__dirname)

--- a/node/sequelize/models/index.js
+++ b/node/sequelize/models/index.js
@@ -9,22 +9,18 @@ require('dotenv').config();
  * 
  * 1. Standard PostgreSQL variables:
  *    - PGHOST: Database host (e.g., "127.0.0.1")
- *    - PGPORT: Database port (default: 5436)
+ *    - PGPORT: Database port (default: 5433)
+ * 
  *    - PGUSER: Database user (default: yugabyte)
  *    - PGPASSWORD: Database password (default: yugabyte)
  *    - PGDATABASE: Database name (default: ysql_sequelize)
  * 
- * 2. Multi-host configuration via config.json:
- *    - For YugabyteDB multi-node load balancing, specify multiple hosts in config.json:
- *      "host": "127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436"
- *    - Environment variable PGHOST takes precedence over config.json
- * 
- * 3. YugabyteDB load balancing variables (extensions to standard PostgreSQL):
- *    - PGLOADBALANCE: Load balancing mode (any, only-primary, prefer-primary, prefer-rr, only-rr)
- *    - PGTOPOLOGYKEYS: Topology awareness keys (e.g., "cloud.region.zone")
+ * 2. Environment variables for the load balancing properties:
+ *    - PGLOADBALANCE: Enable load balancing (Valid values: any, only-primary, prefer-primary, prefer-rr, only-rr)
+ *    - PGTOPOLOGYKEYS: Specify the node placements to target (regions/zones) (e.g., "aws.us-east-1.us-east-1a")
  *    - PGFALLBACKTOTOPOLOGYKEYSONLY: Fallback to topology keys only (default: false)
  *    - PGYBSERVERSREFRESHINTERVAL: Metadata refresh interval in seconds (default: 5)
- *    - PGFAILEDHOSTRECONNECTDELAYSECS: Reconnect delay in seconds (default: 5)
+ *    - PGFAILEDHOSTRECONNECTDELAYSECS: Delay in reconnecting to failed hosts, in seconds (default: 5)
  */
 
 const fs = require('fs');
@@ -41,7 +37,7 @@ const baseConfig = require(path.join(__dirname, '..', 'config', 'config.json'))[
 
 const db = {};
 
-const DEFAULT_YB_PORT = 5436;
+const DEFAULT_YB_PORT = 5433;
 
 const normalizeBooleanEnv = value =>
   typeof value === 'string' ? value.toLowerCase() === 'true' : Boolean(value);
@@ -68,7 +64,7 @@ const HOSTS = (() => {
 
   if (baseConfig.host) {
     // config.json can specify single host or comma-separated multi-host for load balancing
-    // Examples: "127.0.0.1" or "127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436"
+    // Examples: "127.0.0.1" or "127.0.0.1:5433,127.0.0.2:5433,127.0.0.3:5433"
     const hostSpec =
       baseConfig.port && !String(baseConfig.host).includes(':')
         ? `${baseConfig.host}:${baseConfig.port}`
@@ -76,16 +72,11 @@ const HOSTS = (() => {
     return parseHosts(hostSpec);
   }
 
-  // Default to the local 3-node setup (127.0.0.[1-3]:5436) provisioned in docs.
-  return parseHosts('127.0.0.1:5436,127.0.0.2:5436,127.0.0.3:5436');
+  // Default to the local 3-node setup (127.0.0.[1-3]:5433) provisioned in docs.
+  return parseHosts('127.0.0.1:5433,127.0.0.2:5433,127.0.0.3:5433');
 })();
 
-// Load balance mode options: 
-// - 'any': Uses all nodes, least-loaded selection (best for reliability)
-// - 'prefer-rr': Tries read replicas first, falls back to primary
-// - 'only-rr': Only uses read replicas
-// - 'only-primary': Only uses primary nodes
-// - 'prefer-primary': Prefers primary, falls back to read replicas
+// Load balance mode: any, prefer-primary, prefer-rr, only-primary, only-rr
 const READ_LOAD_BALANCE_MODE = process.env.PGLOADBALANCE || "any";
 
 // Optional topology awareness and driver tuning (only set if needed)
@@ -167,9 +158,7 @@ function createSequelizeWithConnectionString() {
     `postgres://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${host}:${port}/${database}` +
     `?loadBalance=${READ_LOAD_BALANCE_MODE}` +
     (TOPOLOGY_KEYS ? `&topologyKeys=${encodeURIComponent(TOPOLOGY_KEYS)}` : '') +
-    `&ybServersRefreshInterval=${SERVER_REFRESH_INTERVAL}` +
-    `&failedHostReconnectDelaySecs=${FAILED_HOST_RECONNECT_DELAY_SECS}` +
-    (FALLBACK_TO_TOPOLOGY_KEYS_ONLY ? `&fallbackToTopologyKeysOnly=true` : '');
+    `&ybServersRefreshInterval=${SERVER_REFRESH_INTERVAL}`;
   
   const logLevel = (process.env.LOG_LEVEL || '').toLowerCase();
   const loggingType = logLevel === 'silly' ? console.log : false;

--- a/node/sequelize/models/index.js
+++ b/node/sequelize/models/index.js
@@ -14,13 +14,17 @@ require('dotenv').config();
  *    - PGPASSWORD: Database password (default: yugabyte)
  *    - PGDATABASE: Database name (default: ysql_sequelize)
  * 
- * 2. Custom multi-host variable (for load balancing):
+ * 2. Custom multi-host variable (for YugabyteDB load balancing):
  *    - PGHOSTS: Comma-separated list of host:port (e.g., "127.0.0.1:5436,127.0.0.2:5436")
- *               Note: This is a custom variable, not standard PostgreSQL. Takes precedence over PGHOST.
+ *               Note: This is a CUSTOM variable (not standard PostgreSQL) needed for YugabyteDB's 
+ *               topology-aware load balancing across multiple nodes. Standard PostgreSQL's PGHOST 
+ *               only supports a single host. PGHOSTS takes precedence over PGHOST when set.
  * 
  * 3. YugabyteDB load balancing variables (extensions to standard PostgreSQL):
  *    - PGLOADBALANCE: Read load balancing mode (any, only-primary, prefer-primary, prefer-rr, only-rr)
- *    - PGWRITELOADBALANCE: Write load balancing mode (default: only-primary)
+ *    - PGWRITELOADBALANCE: Sets the loadBalance property for write connections (default: only-primary)
+ *                          Note: This is NOT a standard YugabyteDB environment variable, it's a custom
+ *                          extension for this example to separately control write load balancing behavior.
  *    - PGTOPOLOGYKEYS: Optional topology awareness keys
  *    - PGFALLBACKTOTOPOLOGYKEYSONLY: Optional fallback to topology keys only (default: false)
  *    - PGYBSERVERSREFRESHINTERVAL: Optional metadata refresh interval in seconds (default: 5)
@@ -162,12 +166,7 @@ function createSmartSequelizeInstance() {
   });
 }
 
-/**
- * Alternative: Using Connection String
- * 
- * This creates a simpler single-connection instance using a PostgreSQL connection URL.
- * Load balancing parameters are passed as query parameters in the URL.
- */
+// Alternative: Using Connection String
 function createSequelizeWithConnectionString() {
   const username = process.env.PGUSER || baseConfig.username || 'yugabyte';
   const password = process.env.PGPASSWORD || (baseConfig.password && baseConfig.password !== '' ? baseConfig.password : 'yugabyte');

--- a/node/sequelize/models/index.js
+++ b/node/sequelize/models/index.js
@@ -98,6 +98,32 @@ const FALLBACK_TO_TOPOLOGY_KEYS_ONLY = normalizeBooleanEnv(process.env.PGFALLBAC
 const SERVER_REFRESH_INTERVAL = process.env.PGYBSERVERSREFRESHINTERVAL ? Number(process.env.PGYBSERVERSREFRESHINTERVAL) : 5;
 const FAILED_HOST_RECONNECT_DELAY_SECS = process.env.PGFAILEDHOSTRECONNECTDELAYSECS ? Number(process.env.PGFAILEDHOSTRECONNECTDELAYSECS) : 5;
 
+// Utility function to set environment variables if not already set
+// The @yugabytedb/pg driver reads these directly from process.env/environment variables
+const ensureEnv = (key, value) => {
+  if (
+    typeof value !== 'undefined' &&
+    value !== null &&
+    value !== '' &&
+    !process.env[key]
+  ) {
+    process.env[key] = String(value);
+  }
+};
+
+// Set environment variables for @yugabytedb/pg driver
+ensureEnv('PGLOADBALANCE', READ_LOAD_BALANCE_MODE);
+ensureEnv('PGTOPOLOGYKEYS', TOPOLOGY_KEYS);
+ensureEnv(
+  'PGFALLBACKTOTOPOLOGYKEYSONLY', 
+  FALLBACK_TO_TOPOLOGY_KEYS_ONLY ? 'true' : undefined,
+);
+ensureEnv('PGYBSERVERSREFRESHINTERVAL', SERVER_REFRESH_INTERVAL);
+ensureEnv(
+  'PGFAILEDHOSTRECONNECTDELAYSECS',
+  FAILED_HOST_RECONNECT_DELAY_SECS,
+);
+
 const SMART_DRIVER_DEFAULTS = {
   ...(TOPOLOGY_KEYS ? { topologyKeys: TOPOLOGY_KEYS } : {}),
   ...(FALLBACK_TO_TOPOLOGY_KEYS_ONLY
@@ -125,31 +151,19 @@ function createSmartSequelizeInstance() {
       ? console.log
       : false;
 
-  // Use all hosts for read replicas (load balancing will handle node selection)
-  const readReplicas = HOSTS;
-
-  const buildConnectionConfig = ({ host, port }, loadBalanceValue) => ({
-    host,
-    port,
-    username,
-    password,
-    database,
-    loadBalance: loadBalanceValue,
-    ...SMART_DRIVER_DEFAULTS,
-  });
-
-  return new Sequelize({
+  // Use single connection with YugabyteDB smart driver for automatic load balancing
+  // The driver will discover all nodes and distribute queries automatically
+  return new Sequelize(database, username, password, {
+    host: primaryHost.host,
+    port: primaryHost.port,
     dialect: 'postgres',
-    database,
-    username,
-    password,
     logging: loggingType,
-    replication: {
-      write: buildConnectionConfig(primaryHost, WRITE_LOAD_BALANCE_MODE),
-      read: readReplicas.map(node =>
-        buildConnectionConfig(node, READ_LOAD_BALANCE_MODE),
-      ),
-    },
+    // YugabyteDB smart driver properties must be at top level, not in dialectOptions
+    loadBalance: READ_LOAD_BALANCE_MODE,
+    topologyKeys: TOPOLOGY_KEYS,
+    fallbackToTopologyKeysOnly: FALLBACK_TO_TOPOLOGY_KEYS_ONLY,
+    ybServersRefreshInterval: SERVER_REFRESH_INTERVAL,
+    failedHostReconnectDelaySecs: FAILED_HOST_RECONNECT_DELAY_SECS,
     pool: {
       max: 10,
       min: 2,

--- a/node/sequelize/package.json
+++ b/node/sequelize/package.json
@@ -8,15 +8,15 @@
     "ensure-db": "node ensure-database.js"
   },
   "dependencies": {
+    "@yugabytedb/pg": "^8.7.3-yb-10",
     "cookie-parser": "~1.4.3",
     "debug": "~2.6.9",
     "express": "^4.19.2",
     "http-errors": "~1.6.2",
     "jade": "~1.11.0",
     "morgan": "~1.9.0",
-    "pg": "npm:@yugabytedb/pg@8.7.3-yb-10",
     "dotenv": "^16.4.7",
-    "sequelize-yugabytedb": "^1.0.5",
+    "sequelize-yugabytedb": "file:../../sequelize-yugabytedb",
     "uuid": "^3.3.2"
   }
 }

--- a/node/sequelize/package.json
+++ b/node/sequelize/package.json
@@ -8,15 +8,15 @@
     "ensure-db": "node ensure-database.js"
   },
   "dependencies": {
-    "@yugabytedb/pg": "^8.7.3-yb-10",
     "cookie-parser": "~1.4.3",
     "debug": "~2.6.9",
     "express": "^4.19.2",
     "http-errors": "~1.6.2",
     "jade": "~1.11.0",
     "morgan": "~1.9.0",
+    "pg": "npm:@yugabytedb/pg@8.7.3-yb-10",
     "dotenv": "^16.4.7",
-    "sequelize-yugabytedb": "file:../../sequelize-yugabytedb",
+    "sequelize-yugabytedb": "^1.0.5",
     "uuid": "^3.3.2"
   }
 }

--- a/node/sequelize/package.json
+++ b/node/sequelize/package.json
@@ -3,16 +3,19 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./bin/www"
+    "prestart": "node ensure-database.js",
+    "start": "node ./bin/www",
+    "ensure-db": "node ensure-database.js"
   },
   "dependencies": {
     "cookie-parser": "~1.4.3",
     "debug": "~2.6.9",
-    "express": "~4.16.0",
+    "express": "^4.19.2",
     "http-errors": "~1.6.2",
     "jade": "~1.11.0",
     "morgan": "~1.9.0",
-    "pg": "^8.6.0",
+    "pg": "npm:@yugabytedb/pg@8.7.3-yb-10",
+    "dotenv": "^16.4.7",
     "sequelize-yugabytedb": "^1.0.5",
     "uuid": "^3.3.2"
   }


### PR DESCRIPTION
Improves YugabyteDB load balancing setup for the Sequelize example

- Adds automatic database creation helper (ensure-database.js) that runs before npm start
- Uses standard PostgreSQL environment variables (PGHOST, PGPORT, PGUSER, etc.)
- Adds support for YugabyteDB smart driver features (load balancing, topology awareness) via PG* environment variables
- Configures sequelize-yugabytedb to use @yugabytedb/pg smart driver for automatic load balancing across cluster nodes
- Updates README with comprehensive examples for environment-based configuration
- Sets default port to 5433 (standard YugabyteDB port) with PGPORT override support for testing
- Simplifies configuration to work seamlessly with RF3 YugabyteDB clusters